### PR TITLE
Add an admin role to users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,3 +39,7 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'web-console', '>= 3.3.0'
 end
+
+group :test do
+  gem 'shoulda-matchers', '~> 3.1'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ group :development, :test do
   gem 'bundler-audit', require: false
   gem 'byebug', platform: :mri
   gem 'dotenv-rails'
+  gem 'factory_girl_rails', '~> 4.0'
   gem 'rspec-rails', '~> 3.5'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,6 +189,8 @@ GEM
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
     shellany (0.0.1)
+    shoulda-matchers (3.1.1)
+      activesupport (>= 4.0.0)
     slim (3.0.7)
       temple (~> 0.7.6)
       tilt (>= 1.3.3, < 2.1)
@@ -251,6 +253,7 @@ DEPENDENCIES
   rails (~> 5.0.1)
   rspec-rails (~> 3.5)
   sass-rails (~> 5.0)
+  shoulda-matchers (~> 3.1)
   slim-rails
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,11 @@ GEM
       activemodel
     erubis (2.7.0)
     execjs (2.7.0)
+    factory_girl (4.8.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.8.0)
+      factory_girl (~> 4.8.0)
+      railties (>= 3.0.0)
     ffi (1.9.17)
     flutie (2.0.0)
     formatador (0.2.5)
@@ -233,6 +238,7 @@ DEPENDENCIES
   clearance (~> 1.16)
   coffee-rails (~> 4.2)
   dotenv-rails
+  factory_girl_rails (~> 4.0)
   flutie (~> 2.0)
   guard
   guard-rspec

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,5 @@
 class User < ApplicationRecord
   include Clearance::User
+
+  enum role: [:user, :admin]
 end

--- a/db/migrate/20170123000943_add_role_to_users.rb
+++ b/db/migrate/20170123000943_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :role, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170122090414) do
+ActiveRecord::Schema.define(version: 20170123000943) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "users", force: :cascade do |t|
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
-    t.string   "email",                          null: false
-    t.string   "encrypted_password", limit: 128, null: false
+    t.datetime "created_at",                                 null: false
+    t.datetime "updated_at",                                 null: false
+    t.string   "email",                                      null: false
+    t.string   "encrypted_password", limit: 128,             null: false
     t.string   "confirmation_token", limit: 128
-    t.string   "remember_token",     limit: 128, null: false
+    t.string   "remember_token",     limit: 128,             null: false
+    t.integer  "role",                           default: 0, null: false
     t.index ["email"], name: "index_users_on_email", using: :btree
     t.index ["remember_token"], name: "index_users_on_remember_token", using: :btree
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,14 @@
+FactoryGirl.define do
+  factory :user do
+    email { Faker::Internet.email }
+    password { 'testing123' }
+
+    trait :admin do
+      role User.roles[:admin]
+    end
+
+    trait :invalid do
+      email nil
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  let(:user) { create(:user) }
+
+  it { is_expected.to define_enum_for(:role).with(user: 0, admin: 1) }
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ require 'spec_helper'
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
+require 'support/factory_girl'
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,8 @@ require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 require 'support/factory_girl'
+require 'support/shoulda_matchers'
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods
+end

--- a/spec/support/shoulda_matchers.rb
+++ b/spec/support/shoulda_matchers.rb
@@ -1,0 +1,16 @@
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    # Choose a test framework:
+    with.test_framework :rspec
+    # with.test_framework :minitest
+    # with.test_framework :minitest_4
+    # with.test_framework :test_unit
+
+    # Choose one or more libraries:
+    # with.library :active_record
+    # with.library :active_model
+    # with.library :action_controller
+    # Or, choose the following (which implies all of the above):
+    with.library :rails
+  end
+end


### PR DESCRIPTION
This update adds an `admin` role to users, which can be used for authorizing users’ access to the upcoming content management area.

In addition, [`factory_girl`](https://github.com/thoughtbot/factory_girl) has been added for fixture data, and [`shoulda-matchers`](https://github.com/thoughtbot/shoulda-matchers) for more succinct testing of common behavior.