### PR TITLE
Use uuid for primary keys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'shrine', '~> 2.5'
 gem 'slim-rails'
 gem 'turbolinks', '~> 5'
 gem 'uglifier', '>= 1.3.0'
+gem 'webdack-uuid_migration'
 
 group :development, :test do
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,6 +281,8 @@ GEM
       activemodel (>= 5.0)
       debug_inspector
       railties (>= 5.0)
+    webdack-uuid_migration (1.0.3)
+      activerecord (>= 4.0)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -328,6 +330,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webdack-uuid_migration
 
 RUBY VERSION
    ruby 2.4.0p0

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,5 +11,13 @@ module ReactionProject
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+    config.active_record.primary_key = :uuid
+
+    config.generators do |g|
+        g.orm :active_record,
+              primary_key_type: :uuid,
+              generate_method: 'uuid_generate_v4()'
+    end
   end
 end

--- a/db/migrate/20170213050447_enable_uuid_extension.rb
+++ b/db/migrate/20170213050447_enable_uuid_extension.rb
@@ -1,0 +1,5 @@
+class EnableUuidExtension < ActiveRecord::Migration[5.0]
+  def change
+    enable_extension 'uuid-ossp' unless extension_enabled?('uuid-ossp')
+  end
+end

--- a/db/migrate/20170213050943_change_primary_keys_to_uuid.rb
+++ b/db/migrate/20170213050943_change_primary_keys_to_uuid.rb
@@ -1,0 +1,20 @@
+require 'webdack/uuid_migration/helpers'
+
+class ChangePrimaryKeysToUuid < ActiveRecord::Migration[5.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        primary_key_and_all_references_to_uuid :actions
+        primary_key_and_all_references_to_uuid :categories
+        primary_key_and_all_references_to_uuid :issues
+
+        primary_key_to_uuid :features
+        primary_key_to_uuid :users
+      end
+
+      dir.down do
+        raise ActiveRecord::IrreversibleMigration
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170208064027) do
+ActiveRecord::Schema.define(version: 20170213050447) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "uuid-ossp"
 
   create_table "actions", force: :cascade do |t|
     t.integer  "issue_id",                        null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -24,7 +24,7 @@ ActiveRecord::Schema.define(version: 20170213050447) do
     t.text     "summary"
     t.text     "body"
     t.string   "time_commitment"
-    t.integer  "priority"
+    t.integer  "priority",        default: 0,     null: false
     t.boolean  "event",           default: false, null: false
     t.string   "location"
     t.datetime "happening_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,21 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170213050447) do
+ActiveRecord::Schema.define(version: 20170213050943) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
-  create_table "actions", force: :cascade do |t|
-    t.integer  "issue_id",                        null: false
-    t.integer  "category_id",                     null: false
+  create_table "actions", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+    t.uuid     "issue_id",                        null: false
+    t.uuid     "category_id",                     null: false
     t.string   "eyebrow"
     t.string   "title",                           null: false
     t.text     "summary"
     t.text     "body"
     t.string   "time_commitment"
-    t.integer  "priority",        default: 0,     null: false
+    t.integer  "priority"
     t.boolean  "event",           default: false, null: false
     t.string   "location"
     t.datetime "happening_at"
@@ -35,22 +35,22 @@ ActiveRecord::Schema.define(version: 20170213050447) do
     t.index ["issue_id"], name: "index_actions_on_issue_id", using: :btree
   end
 
-  create_table "categories", force: :cascade do |t|
+  create_table "categories", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.string   "name",       null: false
     t.text     "icon_data"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "features", force: :cascade do |t|
+  create_table "features", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.integer  "position",   default: 0, null: false
-    t.integer  "action_id",              null: false
+    t.uuid     "action_id",              null: false
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
     t.index ["action_id"], name: "index_features_on_action_id", using: :btree
   end
 
-  create_table "issues", force: :cascade do |t|
+  create_table "issues", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.string   "name",       null: false
     t.text     "lead"
     t.text     "body"
@@ -59,7 +59,7 @@ ActiveRecord::Schema.define(version: 20170213050447) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.datetime "created_at",                                 null: false
     t.datetime "updated_at",                                 null: false
     t.string   "email",                                      null: false


### PR DESCRIPTION
This update migrates primary keys, and all foreign key references, to use UUIDs. This replaces auto-incremental, linear based integer keys, making it easier to eventually scale out across servers.