### PR TITLE
Create an ambassador role

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -1,5 +1,8 @@
 class Issue < ApplicationRecord
   include IssueIconUploader::Attachment.new(:icon)
 
+  has_many :user_issues
+  has_many :users, through: :user_issues
+
   validates :name, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,8 @@
 class User < ApplicationRecord
   include Clearance::User
 
-  enum role: [:user, :admin]
+  enum role: [:user, :admin, :ambassador]
+
   has_many :issues, through: :user_issues
   has_many :user_issues
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,8 @@ class User < ApplicationRecord
   include Clearance::User
 
   enum role: [:user, :admin]
+  has_many :issues, through: :user_issues
+  has_many :user_issues
 
   has_one :profile
 

--- a/app/models/user_issue.rb
+++ b/app/models/user_issue.rb
@@ -1,0 +1,4 @@
+class UserIssue < ApplicationRecord
+  belongs_to :issue
+  belongs_to :user
+end

--- a/db/migrate/20170304051548_create_user_issues.rb
+++ b/db/migrate/20170304051548_create_user_issues.rb
@@ -1,0 +1,13 @@
+class CreateUserIssues < ActiveRecord::Migration[5.0]
+  def change
+    create_table :user_issues, id: :uuid do |t|
+      t.references :user, null: false, foreign_key: { on_delete: :cascade },
+        index: true, type: :uuid
+
+      t.references :issue, null: false, foreign_key: { on_delete: :cascade },
+        index: true, type: :uuid
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170217075210) do
+ActiveRecord::Schema.define(version: 20170304051548) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,6 +72,15 @@ ActiveRecord::Schema.define(version: 20170217075210) do
     t.index ["user_id"], name: "index_profiles_on_user_id", using: :btree
   end
 
+  create_table "user_issues", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+    t.uuid     "user_id",    null: false
+    t.uuid     "issue_id",   null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["issue_id"], name: "index_user_issues_on_issue_id", using: :btree
+    t.index ["user_id"], name: "index_user_issues_on_user_id", using: :btree
+  end
+
   create_table "users", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.datetime "created_at",                                 null: false
     t.datetime "updated_at",                                 null: false
@@ -87,5 +96,7 @@ ActiveRecord::Schema.define(version: 20170217075210) do
   add_foreign_key "actions", "categories", on_delete: :restrict
   add_foreign_key "actions", "issues", on_delete: :restrict
   add_foreign_key "features", "actions"
-  add_foreign_key "profiles", "users", on_delete: :restrict
+  add_foreign_key "profiles", "users"
+  add_foreign_key "user_issues", "issues", on_delete: :cascade
+  add_foreign_key "user_issues", "users", on_delete: :cascade
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,5 +3,7 @@ require 'rails_helper'
 RSpec.describe User, type: :model do
   let(:user) { create(:user) }
 
-  it { is_expected.to define_enum_for(:role).with(user: 0, admin: 1) }
+  it do
+    is_expected.to define_enum_for(:role).with(user: 0, admin: 1, ambassador: 2)
+  end
 end


### PR DESCRIPTION
An ambassador role added to users will allow a user to be tagged as having the capability of updating and modifying Issue content.

For now a simple association of users to issues has been created via a join table (`user_issues`), and the user `role` can determine action authorization. We may eventually need to further clarify the _ambassador_ issue associations against normal _user_ issue associations, but the requirements for this have not yet emerged.

Closes #13 